### PR TITLE
Include Python Scripts Into nightly_build.yml Workflow

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -51,6 +51,7 @@ jobs:
            build/*.iso
            build/*.bat
            build/*.ps1
+           build/*.py
  
   build_installer:
     name: Build installer


### PR DESCRIPTION
Includes Python scripts into the build artifact in the ``nightly_build.yml`` workflow file.