### PR TITLE
Add ``skipifsilent`` Flag to ``Run`` section in Inno Setup Scripts

### DIFF
--- a/src/WinUEFI-setup.iss
+++ b/src/WinUEFI-setup.iss
@@ -67,7 +67,7 @@ Name: "{autodesktop}\WinUEFI (32-bit) Console"; \
     Filename: "{app}\WinUEFI-x86-console.exe"; Tasks: uefi32condesktopicon
 
 [Run]
-Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall; Check: NoRunSwitch
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent; Check: NoRunSwitch
 
 
 [Code]

--- a/src/WinUEFI_nightly-setup.iss
+++ b/src/WinUEFI_nightly-setup.iss
@@ -67,7 +67,7 @@ Name: "{autodesktop}\WinUEFI Nightly (32-bit) Console"; \
     Filename: "{app}\WinUEFI_nightly-x86-console.exe"; Tasks: uefi32condesktopicon
 
 [Run]
-Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall; Check: NoRunSwitch
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent; Check: NoRunSwitch
 
 
 [Code]


### PR DESCRIPTION
This will add the ``skipifsilent`` flag to the application ``Run`` section in both Inno Setup scripts. This would fix issues with Winget tests and might also fix it being detected as virus.